### PR TITLE
Both .md and .markdown should be accepted as extensions

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,8 @@ function gulpMarked(opt) {
     }
 
     // If the ext doesn't match, pass it through
-    if('.md' !== path.extname(file.path)) {
+    var ext = path.extname(file.path);
+    if('.md' !== ext && '.markdown' !== ext) {
       stream.push(file); done();
       return;
     }

--- a/test/marked_test.js
+++ b/test/marked_test.js
@@ -50,6 +50,27 @@ describe('gulp-marked markdown conversion', function() {
 
     });
 
+    it('should convert .markdown files', function(done) {
+
+        var s = marked()
+          , n = 0;
+        s.pipe(es.through(function(file) {
+            expect(file.path).to.equal('bibabelula.html');
+            expect(file.contents.toString('utf-8')).to
+                .equal("<h2 id=\"ohyeah\">ohyeah</h2>\n");
+            n++;
+          }, function() {
+            expect(n).to.equal(1);
+            done();
+          }));
+        s.write(new gutil.File({
+          path: 'bibabelula.markdown',
+          contents: new Buffer('## ohyeah')
+        }));
+        s.end();
+
+    });
+
     it('should convert using a renderer', function(done) {
       var filename = path.join(__dirname, './fixtures/data.md');
       var markdown = fs.readFileSync(filename, { encoding: 'utf8' });


### PR DESCRIPTION
Playing around with building a static site generator, and I have a pile of content with both .md and .markdown extensions. I'd like them both to get caught by marked(). Thanks!
