### PR TITLE
Fix Renderer Option

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ function fileMarked(opt) {
 
     // Create a new Renderer object
     if (opt) {
-      opt.renderer = _.extend(new marked.Renderer(), opt.renderer)
+      opt.renderer = _.extend(opt.renderer, new marked.Renderer())
     }
 
     // Use the buffered content
@@ -41,7 +41,7 @@ function fileMarked(opt) {
 function gulpMarked(opt) {
   // Create a new Renderer object
   if (opt) {
-    opt.renderer = _.extend(new marked.Renderer(), opt.renderer)
+    opt.renderer = _.extend(opt.renderer, new marked.Renderer())
   }
   marked.setOptions(opt || {});
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-marked",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Convert markdown to html with marked.",
   "keywords": [
     "gulpplugin"


### PR DESCRIPTION
The renderer object was being extended like this: `_.extend(new marked.Renderer(), opt.renderer)`. This caused the default renderer to override any properties on the provided renderer.

It would be better to remove the code that manipulates this option. Without it, you can still pass a custom renderer by following the documentation in the [marked](https://github.com/chjj/marked#overriding-renderer-methods) repo.
